### PR TITLE
Increase fetch time for signed addons, and allow automatic TC retries from recoverable errors

### DIFF
--- a/addonscript/exceptions.py
+++ b/addonscript/exceptions.py
@@ -1,8 +1,16 @@
 """addonscript specific exceptions."""
 
+from scriptworker.exceptions import ScriptWorkerRetryException
 
-class SignatureError(Exception):
+
+class SignatureError(ScriptWorkerRetryException):
     """Error when signed XPI is still missing or reported invalid by AMO."""
+
+    pass
+
+
+class FatalSignatureError(Exception):
+    """Fatal error when signed XPI is still missing or reported invalid by AMO."""
 
     pass
 

--- a/addonscript/test/test_api.py
+++ b/addonscript/test/test_api.py
@@ -9,7 +9,7 @@ from addonscript.test import tmpdir
 from scriptworker.context import Context
 
 import addonscript.api as api
-from addonscript.exceptions import SignatureError, AMOConflictError
+from addonscript.exceptions import FatalSignatureError, SignatureError, AMOConflictError
 
 assert tmpdir  # silence flake8
 
@@ -148,7 +148,7 @@ async def test_get_signed_addon_url_validation_errors(context, mocker, errors, r
 
     raisectx = contextlib.suppress()
     if raises:
-        raisectx = pytest.raises(SignatureError)
+        raisectx = pytest.raises(FatalSignatureError)
     with raisectx as excinfo:
         resp = await api.get_signed_addon_url(context, 'en-GB', 'deadbeef')
         assert resp == "https://some-download-url/foo"


### PR DESCRIPTION
Hey Aki (@escapewindow), this should make the tasks auto-retry in TC if they time out, and increase the base checking time for signed langpack results a bit, to try and avoid run's >0 in TC in the first place.