### PR TITLE
Intermittent support

### DIFF
--- a/addonscript/exceptions.py
+++ b/addonscript/exceptions.py
@@ -1,12 +1,18 @@
 """addonscript specific exceptions."""
 
+from scriptworker.constants import STATUSES
 from scriptworker.exceptions import ScriptWorkerRetryException
 
 
 class SignatureError(ScriptWorkerRetryException):
-    """Error when signed XPI is still missing or reported invalid by AMO."""
+    """Error when signed XPI is still missing or reported invalid by AMO.
 
-    pass
+    Attributes:
+        exit_code (int): this is set to 7 (intermittent-task).
+
+    """
+
+    exit_code = STATUSES['intermittent-task']
 
 
 class FatalSignatureError(Exception):

--- a/addonscript/exceptions.py
+++ b/addonscript/exceptions.py
@@ -1,10 +1,10 @@
 """addonscript specific exceptions."""
 
 from scriptworker.constants import STATUSES
-from scriptworker.exceptions import ScriptWorkerRetryException
+from scriptworker.exceptions import ScriptWorkerException, ScriptWorkerTaskException
 
 
-class SignatureError(ScriptWorkerRetryException):
+class SignatureError(ScriptWorkerException):
     """Error when signed XPI is still missing or reported invalid by AMO.
 
     Attributes:
@@ -15,7 +15,7 @@ class SignatureError(ScriptWorkerRetryException):
     exit_code = STATUSES['intermittent-task']
 
 
-class FatalSignatureError(Exception):
+class FatalSignatureError(ScriptWorkerTaskException):
     """Fatal error when signed XPI is still missing or reported invalid by AMO."""
 
     pass


### PR DESCRIPTION
For now I left the current ~10 min (10 retries) per task in place for the check-if-I-am-signed. We can adjust later of course.

jonas assures me that we won't go over max-reruns with this (automatically anyway)