### PR TITLE
avoid deprecation warnings with aiohttp3

### DIFF
--- a/addonscript/api.py
+++ b/addonscript/api.py
@@ -32,7 +32,7 @@ async def do_upload(context, locale):
             result = await amo_put(context, url, data)
         except ClientResponseError as exc:
             # XXX: .code is deprecated in aiohttp 3.1 in favor of .status
-            if exc.code == 409:
+            if exc.status == 409:
                 raise AMOConflictError(
                     "Addon <{}> already present on AMO with version <{}>".format(
                         langpack_id, version,


### PR DESCRIPTION
This should land after https://github.com/mozilla-releng/scriptworker/pull/200 and does not block aiohttp3 rollout.

```
========================================== warnings summary ==========================================
addonscript/test/test_api.py::test_do_upload[401-ClientResponseError]
  /Users/asasaki/src/releng/addonscript/addonscript/api.py:35: DeprecationWarning: code property is deprecated, use status instead
    if exc.code == 409:

addonscript/test/test_api.py::test_do_upload[503-ClientResponseError]
  /Users/asasaki/src/releng/addonscript/addonscript/api.py:35: DeprecationWarning: code property is deprecated, use status instead
    if exc.code == 409:

addonscript/test/test_api.py::test_do_upload[409-AMOConflictError]
  /Users/asasaki/src/releng/addonscript/addonscript/api.py:35: DeprecationWarning: code property is deprecated, use status instead
    if exc.code == 409:

-- Docs: http://doc.pytest.org/en/latest/warnings.html
=============================== 64 passed, 3 warnings in 2.02 seconds ================================
```